### PR TITLE
Use exe location for config

### DIFF
--- a/BgAssist/BigAssistMainForm.cs
+++ b/BgAssist/BigAssistMainForm.cs
@@ -49,7 +49,7 @@ namespace BgAssist
             //Load configuration; validate BGinfo64.exe and .bgi configuration file
             string bginfoArgs = ConfigurationManager.AppSettings.Get("BGinfoArgs");
 
-            string configPath = Directory.GetCurrentDirectory() + "\\BgAssist-Config.exe";
+            string configPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "BgAssist-Config.exe");
 
             Configuration config = ConfigurationManager.OpenExeConfiguration(configPath);
             try


### PR DESCRIPTION
When launching BgAssist via the `Run` key in the registry, it's throwing an error because it can't find the config file. That seems to be due to the system not updating the working directory on that launch.

This PR updates the path that the app looks at to use the path of the EXE, not the working directory from the environment.